### PR TITLE
Clippy

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -155,15 +155,15 @@ fn get_init_standup_copy(latest: Option<&Standup>) -> String {
 }
 
 //fn get_about_prev_day_copy() -> String {
-//    format!(":one: How did *yesterday* go?")
+//    ":one: How did *yesterday* go?".to_string()
 //}
 
 fn get_about_day_copy() -> String {
-    format!(":two: What are you going to be focusing on *today*?")
+    ":two: What are you going to be focusing on *today*?".to_string()
 }
 
 fn get_about_blocker_copy() -> String {
-    format!(":three: Any blockers impacting your work?")
+    ":three: Any blockers impacting your work?".to_string()
 }
 
 fn get_done_copy() -> String {
@@ -175,5 +175,5 @@ fn get_done_copy() -> String {
 
 fn get_complete_copy() -> String {
     // randomize funny quotes
-    format!("You're done for today, off to work you go now! :nerd_face:")
+    "You're done for today, off to work you go now! :nerd_face:".to_string()
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -64,7 +64,7 @@ pub fn react(evt: EventDetails, user: &mut User, standups: &mut StandupList) -> 
             let standup = standups.get_todays_mut(&evt.user).unwrap();
             standup.blocker = Some(msg);
             user.state = UserState::Idle;
-            if let Some(_) = user.channel {
+            if user.channel.is_some() {
                 share_standup(&user, &standup);
             }
             get_done_copy()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,14 +102,14 @@ impl User {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct UserList {
     list: Vec<User>,
 }
 
 impl UserList {
     pub fn new() -> UserList {
-        UserList { list: vec![] }
+        UserList::default()
     }
 
     pub fn find_user(&mut self, username: &str) -> Option<&mut User> {
@@ -143,14 +143,14 @@ impl Standup {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StandupList {
     list: Vec<Standup>,
 }
 
 impl StandupList {
     pub fn new() -> StandupList {
-        StandupList { list: vec![] }
+        StandupList::default()
     }
 
     pub fn add_standup(&mut self, s: Standup) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,10 +113,7 @@ impl UserList {
     }
 
     pub fn find_user(&mut self, username: &str) -> Option<&mut User> {
-        self.list
-            .iter_mut()
-            .filter(|u| u.username == username)
-            .next()
+        self.list.iter_mut().find(|u| u.username == username)
     }
 
     pub fn add_user(&mut self, user: User) {


### PR DESCRIPTION
Fix clippy warnings. I highly recommend the use of cargo clippy for catching little non-idiomatic things.
You can install it with `rustup component add clippy` and run it with `cargo clippy`.
For any clippy lint, you can find the reasoning online. For instance, for `useless_format`: https://rust-lang.github.io/rust-clippy/master/index.html